### PR TITLE
Don't export-ignore verify.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,7 +13,6 @@
 codecov.yml export-ignore
 phpunit.xml.dist export-ignore
 psalm.xml export-ignore
-verify.txt export-ignore
 
 #
 # Auto detect text files and perform LF normalization


### PR DESCRIPTION
This prevented wp s3-uploads verify to work with installed versions of this plugin.