### PR TITLE
Fix the autoloading

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -3,11 +3,7 @@
 namespace S3_Uploads;
 
 function init() {
-	// Ensure the AWS SDK can be loaded.
-	if ( ! class_exists( '\\Aws\\S3\\S3Client' ) ) {
-		// Require AWS Autoloader file.
-		require_once dirname( __DIR__ ) . '/vendor/autoload.php';
-	}
+	require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
 	if ( ! check_requirements() ) {
 		return;

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -4,7 +4,7 @@
 Plugin Name: S3 Uploads
 Description: Store uploads in S3
 Author: Human Made Limited, forked by Denis Zoljom
-Version: 3.4.0
+Version: 3.4.1
 Author URI: https://hmn.md
 */
 


### PR DESCRIPTION
Not sure why, the autoloading is skipped.

TBH I'm unsure how this worked, but it errored out to me locally so I'm putting it back in.

Hopefully this solves the issue where plugin stream class file is wrong...